### PR TITLE
fix rsync source path for tsconfig.base.json

### DIFF
--- a/createIndoqaBootArchetype.sh
+++ b/createIndoqaBootArchetype.sh
@@ -11,7 +11,7 @@ rsync -a -v --delete \
   --include "tsconfig.base.json" \
   --include "tslint.json" \
   --exclude "*" \
-  ../indoqa-react "./indoqa-quickstart-boot"
+  ../indoqa-react/ "./indoqa-quickstart-boot"
 
 # create the archetype project from the project
 cd ./indoqa-quickstart-boot


### PR DESCRIPTION
second rsync was missing trailing / so tsconfig.base.json wasn't copied (at least on mac)